### PR TITLE
Fix the _TYPEs for `char` being unsigned on ARM, which I missed before.

### DIFF
--- a/gcc/config/aarch64/sol2.h
+++ b/gcc/config/aarch64/sol2.h
@@ -54,7 +54,7 @@ along with GCC; see the file COPYING3.  If not see
 
 /* ??? This definition of int8_t follows the system header but does
    not conform to C99.  Likewise int_fast8_t, int_least8_t.  */
-#define INT8_TYPE "char"
+#define INT8_TYPE "signed char"
 #define INT16_TYPE "short int"
 #define INT32_TYPE "int"
 #define INT64_TYPE (LONG_TYPE_SIZE == 64 ? "long int" : "long long int")
@@ -63,7 +63,7 @@ along with GCC; see the file COPYING3.  If not see
 #define UINT32_TYPE "unsigned int"
 #define UINT64_TYPE (LONG_TYPE_SIZE == 64 ? "long unsigned int" : "long long unsigned int")
 
-#define INT_LEAST8_TYPE "char"
+#define INT_LEAST8_TYPE "signed char"
 #define INT_LEAST16_TYPE "short int"
 #define INT_LEAST32_TYPE "int"
 #define INT_LEAST64_TYPE (LONG_TYPE_SIZE == 64 ? "long int" : "long long int")
@@ -72,7 +72,7 @@ along with GCC; see the file COPYING3.  If not see
 #define UINT_LEAST32_TYPE "unsigned int"
 #define UINT_LEAST64_TYPE (LONG_TYPE_SIZE == 64 ? "long unsigned int" : "long long unsigned int")
 
-#define INT_FAST8_TYPE "char"
+#define INT_FAST8_TYPE "signed char"
 #define INT_FAST16_TYPE "int"
 #define INT_FAST32_TYPE "int"
 #define INT_FAST64_TYPE (LONG_TYPE_SIZE == 64 ? "long int" : "long long int")


### PR DESCRIPTION
This broke surprisingly few things we noticed, but among them was gdb which got very confused.

@citrus-it @hadfl can you try this out with the omnios stuff?