### PR TITLE
msave-args: preserve integer function arguments passed in registers

### DIFF
--- a/gcc/config/aarch64/aarch64.opt
+++ b/gcc/config/aarch64/aarch64.opt
@@ -91,6 +91,10 @@ mcmodel=
 Target RejectNegative Joined Enum(cmodel) Var(aarch64_cmodel_var) Init(AARCH64_CMODEL_SMALL) Save
 Specify the code model.
 
+msave-args
+Target Report Mask(SAVE_ARGS)
+Save integer arguments on the stack at function entry.
+
 mstrict-align
 Target Report Mask(STRICT_ALIGN) Save
 Don't assume that unaligned accesses are handled by the system.


### PR DESCRIPTION
Similar to on amd64, it would be convenient if we could preserve call-time function arguments in the stack frame for use by the debuggers.

Implement a prototype of that which works by telling the compiler that the argument registers (x0-x7) are callee saved, and must be preserved, which does what we want at, though is perhaps not the most future-proof.

@citrus-it