### PR TITLE
Clean up configuration / Enable LSE (in gcc at least) on illumos

### DIFF
--- a/gcc/config/aarch64/sol2.h
+++ b/gcc/config/aarch64/sol2.h
@@ -409,6 +409,13 @@ along with GCC; see the file COPYING3.  If not see
 /* Static stack checking is supported by means of probes.  */
 #define STACK_CHECK_STATIC_BUILTIN 1
 
+/* The illumos linker will not merge a read-only .eh_frame section with a
+   read-write .eh_frame section.  None of the encodings used with non-PIC code
+   require runtime relocations. Since there is no backwards compatibility
+   issue, we use a read-only section for .eh_frame. */
+#undef EH_TABLES_CAN_BE_READ_ONLY
+#define EH_TABLES_CAN_BE_READ_ONLY 1
+
 #define TARGET_POSIX_IO
 
 /* Solaris 10 has the float and long double forms of math functions.

--- a/gcc/configure
+++ b/gcc/configure
@@ -23986,6 +23986,13 @@ else
 	    gcc_cv_as_cfi_directive=no
 	  fi
 	  ;;
+	aarch64-*-solaris2.*)
+	  if gcc_fn_eh_frame_ro; then
+	    gcc_cv_as_cfi_directive=yes
+	  else
+	    gcc_cv_as_cfi_directive=no
+	  fi
+	  ;;
       esac
     fi
     ;;
@@ -24289,7 +24296,7 @@ if test $gcc_cv_as_section_exclude_e = no; then
 	sparc*-*-solaris2*)
 	  conftest_s='.section "foo1", #exclude'
 	  ;;
-	i?86-*-solaris2* | x86_64-*-solaris2*)
+	i?86-*-solaris2* | x86_64-*-solaris2* | aarch64-*-solaris2* )
 	  conftest_s='.section foo1, #exclude'
 	  ;;
       esac
@@ -29929,6 +29936,9 @@ else
          if test -h "$target_libdir/gcrt1.o"; then gcc_cv_solaris_crts=yes; fi
 	 ;;
        sparc*-*-solaris2*)
+         if test -f "$target_libdir/crt1.o"; then gcc_cv_solaris_crts=yes; fi
+	 ;;
+       aarch64*-*-solaris2*)
          if test -f "$target_libdir/crt1.o"; then gcc_cv_solaris_crts=yes; fi
 	 ;;
      esac

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -3102,6 +3102,13 @@ gcc_GAS_CHECK_FEATURE([cfi directives], gcc_cv_as_cfi_directive,
 	    gcc_cv_as_cfi_directive=no
 	  fi
 	  ;;
+	aarch64-*-solaris2.*)
+	  if gcc_fn_eh_frame_ro; then
+	    gcc_cv_as_cfi_directive=yes
+	  else
+	    gcc_cv_as_cfi_directive=no
+	  fi
+	  ;;
       esac
     fi
     ;;
@@ -3257,7 +3264,7 @@ if test $gcc_cv_as_section_exclude_e = no; then
 	sparc*-*-solaris2*)
 	  conftest_s='.section "foo1", #exclude'
 	  ;;
-	i?86-*-solaris2* | x86_64-*-solaris2*)
+	i?86-*-solaris2* | x86_64-*-solaris2* | aarch64-*-solaris2*)
 	  conftest_s='.section foo1, #exclude'
 	  ;;      
       esac
@@ -6245,6 +6252,9 @@ case $target in
          if test -h "$target_libdir/gcrt1.o"; then gcc_cv_solaris_crts=yes; fi
 	 ;;
        sparc*-*-solaris2*)
+         if test -f "$target_libdir/crt1.o"; then gcc_cv_solaris_crts=yes; fi
+	 ;;
+       aarch64*-*-solaris2*)
          if test -f "$target_libdir/crt1.o"; then gcc_cv_solaris_crts=yes; fi
 	 ;;
      esac])

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -415,7 +415,7 @@ aarch64*-*-vxworks7*)
 	;;
 aarch64*-*-solaris2*)
 	tmake_file="${tmake_file} ${cpu_type}/t-aarch64 aarch64/t-sol2"
-	tmake_file="${tmake_file} ${cpu_type}/t-softfp t-softfp t-crtfm"
+	tmake_file="${tmake_file} ${cpu_type}/t-lse ${cpu_type}/t-softfp t-softfp t-crtfm"
 	extra_parts="$extra_parts crtfastmath.o crtbeginS.o crtendS.o"
 	md_unwind_header=aarch64/aarch64-unwind.h
 	;;

--- a/libgcc/config/aarch64/lse-init.c
+++ b/libgcc/config/aarch64/lse-init.c
@@ -31,7 +31,7 @@ _Bool __aarch64_have_lse_atomics
 
 /* Gate availability of __getauxval on glibc.  All AArch64-supporting glibc
    versions support it.  */
-#ifdef __gnu_linux__
+#if defined(__gnu_linux__)
 
 # define AT_HWCAP	16
 # define HWCAP_ATOMICS	(1 << 8)
@@ -45,4 +45,17 @@ init_have_lse_atomics (void)
   __aarch64_have_lse_atomics = (hwcap & HWCAP_ATOMICS) != 0;
 }
 
-#endif /* __gnu_linux__  */
+#elif defined(__illumos__) /* __gnu_linux__  */
+
+#include <sys/auxv.h>
+
+static void __attribute__((constructor))
+init_have_lse_atomics (void)
+{
+  uint32_t hwc[2] = {0};
+
+  (void) getisax(&hwc, 2);
+
+  __aarch64_have_lse_atomics = (hwc[0] & AV_AARCH64_LSE) != 0;
+}
+#endif

--- a/libgcc/configure
+++ b/libgcc/configure
@@ -5116,6 +5116,9 @@ else
        sparc*-*-solaris2*)
          if test -f "$libgcc_libdir/crt1.o"; then libgcc_cv_solaris_crts=yes; fi
 	 ;;
+       aarch64*-*-solaris2*)
+         if test -f "$libgcc_libdir/crt1.o"; then libgcc_cv_solaris_crts=yes; fi
+	 ;;
      esac
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_solaris_crts" >&5

--- a/libgcc/configure.ac
+++ b/libgcc/configure.ac
@@ -356,6 +356,9 @@ case ${host} in
        sparc*-*-solaris2*)
          if test -f "$libgcc_libdir/crt1.o"; then libgcc_cv_solaris_crts=yes; fi
 	 ;;
+       aarch64*-*-solaris2*)
+         if test -f "$libgcc_libdir/crt1.o"; then libgcc_cv_solaris_crts=yes; fi
+	 ;;
      esac])
   if test $libgcc_cv_solaris_crts = yes; then
     AC_DEFINE(HAVE_SOLARIS_CRTS, 1,


### PR DESCRIPTION
This cleans up a number of places where we seemed to have slipped through the net being an aarch64 illumos.  Most importantly, it fixes `.eh_frame` to have consistent attributes, which should help omnios-build and omnios-extra.

Also teach GCC that LSE exists for an illumos target, and implement sniffing for the LSE feature (this won't work, because it turns out we don't boot on any CPU that has it..., I guess that's a future adventure).  This means that you no longer need `-mno-outline-atomics` anymore if you're in a place you can use libgcc (unfortunately, not illumos), like omnios etc.

I tested that last part by stepping in mdb and checking the return of getisax v. knowing what the flags should be, etc, so I have as much faith as I can for code that can't take the important branch...

@citrus-it @hadfl I think you'd both asked me before about needing `-mno-outline-atomics` in omnios, do you want to see if this helps you? or take a look? 